### PR TITLE
Add `wallet_electrum` example and various improvements

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -23,7 +23,7 @@ pub use bdk_chain::keychain::Balance;
 use bdk_chain::{
     chain_graph,
     keychain::{persist, KeychainChangeSet, KeychainScan, KeychainTracker},
-    sparse_chain, BlockId, ConfirmationTime, IntoOwned,
+    sparse_chain, BlockId, ConfirmationTime,
 };
 use bitcoin::consensus::encode::serialize;
 use bitcoin::secp256k1::Secp256k1;
@@ -91,11 +91,11 @@ pub struct Wallet<D = ()> {
 
 /// The update to a [`Wallet`] used in [`Wallet::apply_update`]. This is usually returned from blockchain data sources.
 /// The type parameter `T` indicates the kind of transaction contained in the update. It's usually a [`bitcoin::Transaction`].
-pub type Update<T> = KeychainScan<KeychainKind, ConfirmationTime, T>;
+pub type Update = KeychainScan<KeychainKind, ConfirmationTime>;
 /// Error indicating that something was wrong with an [`Update<T>`].
 pub type UpdateError = chain_graph::UpdateError<ConfirmationTime>;
 /// The changeset produced internally by applying an update
-pub(crate) type ChangeSet = KeychainChangeSet<KeychainKind, ConfirmationTime, Transaction>;
+pub(crate) type ChangeSet = KeychainChangeSet<KeychainKind, ConfirmationTime>;
 
 /// The address index selection strategy to use to derived an address from the wallet's external
 /// descriptor. See [`Wallet::get_address`]. If you're unsure which one to use use `WalletIndex::New`.
@@ -1686,10 +1686,9 @@ impl<D> Wallet<D> {
     /// transactions related to your wallet into it.
     ///
     /// [`commit`]: Self::commit
-    pub fn apply_update<Tx>(&mut self, update: Update<Tx>) -> Result<(), UpdateError>
+    pub fn apply_update(&mut self, update: Update) -> Result<(), UpdateError>
     where
         D: persist::PersistBackend<KeychainKind, ConfirmationTime>,
-        Tx: IntoOwned<Transaction> + Clone,
     {
         let changeset = self.keychain_tracker.apply_update(update)?;
         self.persist.stage(changeset);

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -1711,6 +1711,28 @@ impl<D> Wallet<D> {
     pub fn staged(&self) -> &ChangeSet {
         self.persist.staged()
     }
+
+    /// Get a reference to the inner [`TxGraph`](bdk_chain::tx_graph::TxGraph).
+    pub fn as_graph(&self) -> &bdk_chain::tx_graph::TxGraph {
+        self.keychain_tracker.graph()
+    }
+
+    /// Get a reference to the inner [`ChainGraph`](bdk_chain::chain_graph::ChainGraph).
+    pub fn as_chain_graph(&self) -> &bdk_chain::chain_graph::ChainGraph<ConfirmationTime> {
+        self.keychain_tracker.chain_graph()
+    }
+}
+
+impl<D> AsRef<bdk_chain::tx_graph::TxGraph> for Wallet<D> {
+    fn as_ref(&self) -> &bdk_chain::tx_graph::TxGraph {
+        self.keychain_tracker.graph()
+    }
+}
+
+impl<D> AsRef<bdk_chain::chain_graph::ChainGraph<ConfirmationTime>> for Wallet<D> {
+    fn as_ref(&self) -> &bdk_chain::chain_graph::ChainGraph<ConfirmationTime> {
+        self.keychain_tracker.chain_graph()
+    }
 }
 
 /// Deterministically generate a unique name given the descriptors defining the wallet

--- a/crates/chain/src/sparse_chain.rs
+++ b/crates/chain/src/sparse_chain.rs
@@ -311,7 +311,7 @@ use core::{
     ops::{Bound, RangeBounds},
 };
 
-use crate::{collections::*, tx_graph::TxGraph, AsTransaction, BlockId, FullTxOut, TxHeight};
+use crate::{collections::*, tx_graph::TxGraph, BlockId, FullTxOut, TxHeight};
 use bitcoin::{hashes::Hash, BlockHash, OutPoint, Txid};
 
 /// This is a non-monotone structure that tracks relevant [`Txid`]s that are ordered by chain
@@ -899,16 +899,12 @@ impl<P: ChainPosition> SparseChain<P> {
     /// Attempt to retrieve a [`FullTxOut`] of the given `outpoint`.
     ///
     /// This will return `Some` only if the output's transaction is in both `self` and `graph`.
-    pub fn full_txout(
-        &self,
-        graph: &TxGraph<impl AsTransaction>,
-        outpoint: OutPoint,
-    ) -> Option<FullTxOut<P>> {
+    pub fn full_txout(&self, graph: &TxGraph, outpoint: OutPoint) -> Option<FullTxOut<P>> {
         let chain_pos = self.tx_position(outpoint.txid)?;
 
         let tx = graph.get_tx(outpoint.txid)?;
-        let is_on_coinbase = tx.as_tx().is_coin_base();
-        let txout = tx.as_tx().output.get(outpoint.vout as usize)?.clone();
+        let is_on_coinbase = tx.is_coin_base();
+        let txout = tx.output.get(outpoint.vout as usize)?.clone();
 
         let spent_by = self
             .spent_by(graph, outpoint)
@@ -976,7 +972,7 @@ impl<P: ChainPosition> SparseChain<P> {
     ///
     /// Note that the transaction including `outpoint` does not need to be in the `graph` or the
     /// `chain` for this to return `Some`.
-    pub fn spent_by<T>(&self, graph: &TxGraph<T>, outpoint: OutPoint) -> Option<(&P, Txid)> {
+    pub fn spent_by(&self, graph: &TxGraph, outpoint: OutPoint) -> Option<(&P, Txid)> {
         graph
             .outspends(outpoint)
             .iter()

--- a/crates/chain/src/tx_data_traits.rs
+++ b/crates/chain/src/tx_data_traits.rs
@@ -1,6 +1,3 @@
-use core::borrow::Borrow;
-
-use alloc::{borrow::Cow, boxed::Box, rc::Rc, sync::Arc};
 use bitcoin::{Block, OutPoint, Transaction, TxOut};
 
 /// Trait to do something with every txout contained in a structure.
@@ -20,58 +17,10 @@ impl ForEachTxOut for Block {
     }
 }
 
-/// Trait for things that have a single [`Transaction`] in them.
-///
-/// This alows polymorphism in structures such as [`TxGraph<T>`] where `T` can be anything that
-/// implements `AsTransaction`. You might think that we could just use [`core::convert::AsRef`] for
-/// this but the problem is that we need to implement it on `Cow<T>` where `T: AsTransaction` which
-/// we can't do with a foreign trait like `AsTransaction`.
-///
-/// [`Transaction`]: bitcoin::Transaction
-/// [`TxGraph<T>`]: crate::tx_graph::TxGraph
-pub trait AsTransaction {
-    /// Get a reference to the transaction.
-    fn as_tx(&self) -> &Transaction;
-}
-
-impl AsTransaction for Transaction {
-    fn as_tx(&self) -> &Transaction {
-        self
-    }
-}
-
-impl<T: AsTransaction> AsTransaction for Rc<T> {
-    fn as_tx(&self) -> &Transaction {
-        self.as_ref().as_tx()
-    }
-}
-
-impl<T: AsTransaction> AsTransaction for Arc<T> {
-    fn as_tx(&self) -> &Transaction {
-        self.as_ref().as_tx()
-    }
-}
-
-impl<T: AsTransaction> AsTransaction for Box<T> {
-    fn as_tx(&self) -> &Transaction {
-        self.as_ref().as_tx()
-    }
-}
-
-impl<'a, T: AsTransaction + Clone> AsTransaction for Cow<'a, T> {
-    fn as_tx(&self) -> &Transaction {
-        <Cow<'_, T> as Borrow<T>>::borrow(self).as_tx()
-    }
-}
-
-impl<T> ForEachTxOut for T
-where
-    T: AsTransaction,
-{
+impl ForEachTxOut for Transaction {
     fn for_each_txout(&self, mut f: impl FnMut((OutPoint, &TxOut))) {
-        let tx = self.as_tx();
-        let txid = tx.txid();
-        for (i, txout) in tx.output.iter().enumerate() {
+        let txid = self.txid();
+        for (i, txout) in self.output.iter().enumerate() {
             f((
                 OutPoint {
                     txid,
@@ -80,36 +29,5 @@ where
                 txout,
             ))
         }
-    }
-}
-
-/// A trait like [`core::convert::Into`] for converting one thing into another.
-///
-/// We use it to convert one transaction type into another so that an update for `T2` can be used on
-/// a `TxGraph<T1>` as long as `T2: IntoOwned<T1>`.
-///
-/// We couldn't use `Into` because we needed to implement it for [`Cow<'a, T>`].
-///
-/// [`Cow<'a, T>`]: std::borrow::Cow
-pub trait IntoOwned<T> {
-    /// Converts the provided type into another (owned) type.
-    fn into_owned(self) -> T;
-}
-
-impl<T> IntoOwned<T> for T {
-    fn into_owned(self) -> T {
-        self
-    }
-}
-
-impl<'a, T: Clone> IntoOwned<T> for Cow<'a, T> {
-    fn into_owned(self) -> T {
-        Cow::into_owned(self)
-    }
-}
-
-impl<'a, T: Clone> IntoOwned<T> for &'a T {
-    fn into_owned(self) -> T {
-        self.clone()
     }
 }

--- a/crates/chain/tests/test_chain_graph.rs
+++ b/crates/chain/tests/test_chain_graph.rs
@@ -124,7 +124,7 @@ fn update_evicts_conflicting_tx() {
             cg
         };
 
-        let changeset = ChangeSet::<TxHeight, Transaction> {
+        let changeset = ChangeSet::<TxHeight> {
             chain: sparse_chain::ChangeSet {
                 checkpoints: Default::default(),
                 txids: [
@@ -203,7 +203,7 @@ fn update_evicts_conflicting_tx() {
             cg
         };
 
-        let changeset = ChangeSet::<TxHeight, Transaction> {
+        let changeset = ChangeSet::<TxHeight> {
             chain: sparse_chain::ChangeSet {
                 checkpoints: [(1, Some(h!("B'")))].into(),
                 txids: [
@@ -287,7 +287,7 @@ fn chain_graph_new_missing() {
 
     let new_graph = ChainGraph::new(update.clone(), graph.clone()).unwrap();
     let expected_graph = {
-        let mut cg = ChainGraph::<TxHeight, Transaction>::default();
+        let mut cg = ChainGraph::<TxHeight>::default();
         let _ = cg
             .insert_checkpoint(update.latest_checkpoint().unwrap())
             .unwrap();

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -35,7 +35,7 @@ fn insert_txouts() {
     )];
 
     let mut graph = {
-        let mut graph = TxGraph::<Transaction>::default();
+        let mut graph = TxGraph::default();
         for (outpoint, txout) in &original_ops {
             assert_eq!(
                 graph.insert_txout(*outpoint, txout.clone()),
@@ -49,7 +49,7 @@ fn insert_txouts() {
     };
 
     let update = {
-        let mut graph = TxGraph::<Transaction>::default();
+        let mut graph = TxGraph::default();
         for (outpoint, txout) in &update_ops {
             assert_eq!(
                 graph.insert_txout(*outpoint, txout.clone()),
@@ -362,7 +362,7 @@ fn test_calculate_fee_on_coinbase() {
         output: vec![TxOut::default()],
     };
 
-    let graph = TxGraph::<Transaction>::default();
+    let graph = TxGraph::default();
 
     assert_eq!(graph.calculate_fee(&tx), Some(0));
 }

--- a/crates/electrum/src/lib.rs
+++ b/crates/electrum/src/lib.rs
@@ -21,7 +21,6 @@
 //! [`bdk_electrum_example`]: https://github.com/LLFourn/bdk_core_staging/tree/master/bdk_electrum_example
 
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
 };
@@ -249,7 +248,7 @@ impl<K: Ord + Clone + Debug, P: ChainPosition> ElectrumUpdate<K, P> {
         self,
         new_txs: Vec<T>,
         chain_graph: &CG,
-    ) -> Result<KeychainScan<K, P, Cow<T>>, chain_graph::NewError<P>>
+    ) -> Result<KeychainScan<K, P, T>, chain_graph::NewError<P>>
     where
         T: AsTransaction + Clone + Ord,
         CG: AsRef<ChainGraph<P, T>>,

--- a/crates/electrum/src/lib.rs
+++ b/crates/electrum/src/lib.rs
@@ -32,7 +32,7 @@ use bdk_chain::{
     keychain::KeychainScan,
     sparse_chain::{self, ChainPosition, SparseChain},
     tx_graph::TxGraph,
-    AsTransaction, BlockId, ConfirmationTime, TxHeight,
+    BlockId, ConfirmationTime, TxHeight,
 };
 pub use electrum_client;
 use electrum_client::{Client, ElectrumApi, Error};
@@ -228,10 +228,9 @@ impl<K: Ord + Clone + Debug, P: ChainPosition> ElectrumUpdate<K, P> {
     /// Return a list of missing full transactions that are required to [`inflate_update`].
     ///
     /// [`inflate_update`]: bdk_chain::chain_graph::ChainGraph::inflate_update
-    pub fn missing_full_txs<T, G>(&self, graph: G) -> Vec<&Txid>
+    pub fn missing_full_txs<G>(&self, graph: G) -> Vec<&Txid>
     where
-        T: AsTransaction,
-        G: AsRef<TxGraph<T>>,
+        G: AsRef<TxGraph>,
     {
         self.chain_update
             .txids()
@@ -244,14 +243,13 @@ impl<K: Ord + Clone + Debug, P: ChainPosition> ElectrumUpdate<K, P> {
     /// `tracker`.
     ///
     /// This will fail if there are missing full transactions not provided via `new_txs`.
-    pub fn into_keychain_scan<T, CG>(
+    pub fn into_keychain_scan<CG>(
         self,
-        new_txs: Vec<T>,
+        new_txs: Vec<Transaction>,
         chain_graph: &CG,
-    ) -> Result<KeychainScan<K, P, T>, chain_graph::NewError<P>>
+    ) -> Result<KeychainScan<K, P>, chain_graph::NewError<P>>
     where
-        T: AsTransaction + Clone + Ord,
-        CG: AsRef<ChainGraph<P, T>>,
+        CG: AsRef<ChainGraph<P>>,
     {
         Ok(KeychainScan {
             update: chain_graph

--- a/crates/file_store/src/lib.rs
+++ b/crates/file_store/src/lib.rs
@@ -1,6 +1,5 @@
 mod file_store;
 use bdk_chain::{
-    bitcoin::Transaction,
     keychain::{KeychainChangeSet, KeychainTracker, PersistBackend},
     sparse_chain::ChainPosition,
 };
@@ -10,7 +9,7 @@ impl<K, P> PersistBackend<K, P> for KeychainStore<K, P>
 where
     K: Ord + Clone + core::fmt::Debug,
     P: ChainPosition,
-    KeychainChangeSet<K, P, Transaction>: serde::Serialize + serde::de::DeserializeOwned,
+    KeychainChangeSet<K, P>: serde::Serialize + serde::de::DeserializeOwned,
 {
     type WriteError = std::io::Error;
 

--- a/example-crates/wallet_electrum/Cargo.toml
+++ b/example-crates/wallet_electrum/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 bdk = { path = "../../crates/bdk" }
+bdk_electrum = { path = "../../crates/electrum" }
+bdk_file_store = { path = "../../crates/file_store" }

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -1,3 +1,83 @@
-fn main() {
+use std::str::FromStr;
+
+use bdk::{
+    bitcoin::{Address, Network},
+    SignOptions, Wallet,
+};
+use bdk_electrum::{
+    electrum_client::{self, ElectrumApi},
+    ElectrumExt,
+};
+use bdk_file_store::KeychainStore;
+
+const SEND_AMOUNT: u64 = 5000;
+const STOP_GAP: usize = 50;
+const BATCH_SIZE: usize = 5;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Hello, world!");
+
+    let db_path = std::env::temp_dir().join("bdk-electrum-example");
+    let db = KeychainStore::new_from_path(db_path)?;
+    let external_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/0'/0'/0/*)";
+    let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/0'/0'/1/*)";
+
+    let mut wallet = Wallet::new(
+        external_descriptor,
+        Some(internal_descriptor),
+        db,
+        Network::Testnet,
+    )?;
+
+    let address = wallet.get_address(bdk::wallet::AddressIndex::New);
+    println!("Generated Address: {}", address);
+
+    let balance = wallet.get_balance();
+    println!("Wallet balance before syncing: {} sats", balance.total());
+
+    println!("Syncing...");
+    // Scanning the chain...
+    let electrum_url = "ssl://electrum.blockstream.info:60002";
+    let client = electrum_client::Client::new(electrum_url)?;
+    let local_chain = wallet.checkpoints();
+    let spks = wallet.spks_of_all_keychains();
+    let electrum_update = client
+        .scan(
+            local_chain,
+            spks,
+            core::iter::empty(),
+            core::iter::empty(),
+            STOP_GAP,
+            BATCH_SIZE,
+        )?
+        .into_confirmation_time_update(&client)?;
+    let new_txs = client.batch_transaction_get(electrum_update.missing_full_txs(&wallet))?;
+    let update = electrum_update.into_keychain_scan(new_txs, &wallet)?;
+    wallet.apply_update(update)?;
+    wallet.commit()?;
+
+    let balance = wallet.get_balance();
+    println!("Wallet balance after syncing: {} sats", balance.total());
+
+    if balance.total() == 0 {
+        println!("Please send some coins to the receiving address");
+        std::process::exit(0);
+    }
+
+    let faucet_address = Address::from_str("mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt")?;
+
+    let mut tx_builder = wallet.build_tx();
+    tx_builder
+        .add_recipient(faucet_address.script_pubkey(), SEND_AMOUNT)
+        .enable_rbf();
+
+    let (mut psbt, _) = tx_builder.finish()?;
+    let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
+    assert!(finalized);
+
+    let tx = psbt.extract_tx();
+    client.transaction_broadcast(&tx)?;
+    println!("Tx broadcasted! Txid: {}", tx.txid());
+
+    Ok(())
 }

--- a/example-crates/wallet_esplora/src/main.rs
+++ b/example-crates/wallet_esplora/src/main.rs
@@ -8,6 +8,7 @@ use bdk_esplora::EsploraExt;
 use bdk_file_store::KeychainStore;
 use std::str::FromStr;
 
+const SEND_AMOUNT: u64 = 5000;
 const STOP_GAP: usize = 50;
 const PARALLEL_REQUESTS: usize = 5;
 
@@ -58,7 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tx_builder = wallet.build_tx();
     tx_builder
-        .add_recipient(faucet_address.script_pubkey(), (balance.total()) / 5)
+        .add_recipient(faucet_address.script_pubkey(), SEND_AMOUNT)
         .enable_rbf();
 
     let (mut psbt, _) = tx_builder.finish()?;

--- a/example-crates/wallet_esplora/src/main.rs
+++ b/example-crates/wallet_esplora/src/main.rs
@@ -13,7 +13,8 @@ const STOP_GAP: usize = 50;
 const PARALLEL_REQUESTS: usize = 5;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let db = KeychainStore::new_from_path("/tmp/bdk-esplora-example")?;
+    let db_path = std::env::temp_dir().join("bdk-esplora-example");
+    let db = KeychainStore::new_from_path(db_path)?;
     let external_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/0'/0'/0/*)";
     let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/0'/0'/1/*)";
 


### PR DESCRIPTION
### Description

Add `wallet_electrum` example. Also, because of the use of `Cow` in `bdk_core` structures, `KeychainScan` could not be directly applied to the `Wallet`. The solution to this (as implemented in this PR) is to remove the use of `Cow` completely, and change the logic of `inflate_changeset` as mentioned by @LLFourn:

> 1. We have a "sparse chain" from which there is a subset of txids M that are missing from graph.
> 2. There is also another subset C that are in the graph but their positions have changed.
> 3. We used the Cow to avoid copying/duplicating in memory transactions in subset C and M
> 
> Instead in inflate_update we could remove transactions in subset M and just clone data in subset C (which is usually tiny).

In addition to this, there is various "improvements" to the `wallet_esplora` example as well.
